### PR TITLE
feat: retrieve next node addr

### DIFF
--- a/src/elevator/types.go
+++ b/src/elevator/types.go
@@ -1,8 +1,13 @@
 package elevator
 
+type Next struct {
+	ID   int
+	Addr string
+}
+
 type Elevator struct {
 	NodeID        int
 	NumNodes      int
 	BroadCastPort int
-	NextNodeAddr  string
+	Next          Next
 }

--- a/src/elevator/types.go
+++ b/src/elevator/types.go
@@ -1,7 +1,8 @@
 package elevator
 
 type Elevator struct {
-	NodeID          int
-	NumNodes        int
-	BroadCastPort   int
+	NodeID        int
+	NumNodes      int
+	BroadCastPort int
+	NextNodeAddr  string
 }

--- a/src/elevator/types.go
+++ b/src/elevator/types.go
@@ -1,6 +1,6 @@
 package elevator
 
-type Next struct {
+type NextNode struct {
 	ID   int
 	Addr string
 }
@@ -9,5 +9,5 @@ type Elevator struct {
 	NodeID        int
 	NumNodes      int
 	BroadCastPort int
-	Next          Next
+	NextNode          NextNode
 }

--- a/src/elevator/types.go
+++ b/src/elevator/types.go
@@ -9,5 +9,5 @@ type Elevator struct {
 	NodeID        int
 	NumNodes      int
 	BroadCastPort int
-	NextNode          NextNode
+	NextNode      NextNode
 }

--- a/src/main.go
+++ b/src/main.go
@@ -50,8 +50,6 @@ func main() {
 		nextNodeID = elevState.NodeID + 1
 	}
 
-	fmt.Println(nextNodeID)
-
 	updateNextNode := make(chan elevator.Next)
 
 	go network.MonitorNext(

--- a/src/main.go
+++ b/src/main.go
@@ -50,9 +50,9 @@ func main() {
 		nextNodeID = elevState.NodeID + 1
 	}
 
-	updateNextNode := make(chan elevator.Next)
+	updateNextNode := make(chan elevator.NextNode)
 
-	go network.MonitorNext(
+	go network.MonitorNextNode(
 		elevState.NodeID,
 		elevState.NumNodes,
 		*basePort,
@@ -64,13 +64,13 @@ func main() {
 	for {
 		select {
 		case newNextNode := <-updateNextNode:
-			elevState.Next = newNextNode
+			elevState.NextNode = newNextNode
 
 			/*
 			 * Temporary display id and next node
 			 */
 			fmt.Print("\033[J\033[2;0H\r  ")
-			fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ", elevState.NodeID, elevState.Next.ID, elevState.Next.Addr)
+			fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ", elevState.NodeID, elevState.NextNode.ID, elevState.NextNode.Addr)
 
 		default:
 			/*

--- a/src/main.go
+++ b/src/main.go
@@ -24,6 +24,11 @@ func main() {
 	}
 
 	/*
+	 * Clear terminal window
+	 */
+	fmt.Print("\033[2J")
+
+	/*
 	 * Initiate elevator state
 	 */
 	elevState, err := elevator.InitElevator(*nodeID, *numNodes, *basePort)
@@ -32,15 +37,10 @@ func main() {
 		panic(err)
 	}
 
-	/*
-	 * Clear terminal window
-	 */
-	fmt.Print("\033[2J")
-
 	go network.Broadcast(elevState.BroadCastPort)
 
 	/*
-	 * Monitor next nodes and update NextNodeAddr
+	 * Monitor next nodes and update NextNode in elevState
 	 */
 	var nextNodeID int
 

--- a/src/network/broadcast.go
+++ b/src/network/broadcast.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 	"time"
@@ -29,14 +28,10 @@ func Broadcast(port int) {
 		panic(err)
 	}
 
-	buf := make([]byte, 4)
-
 	for {
 		time.Sleep(BROADCAST_INTERVAL * time.Millisecond)
 
-		binary.BigEndian.PutUint32(buf, uint32(port))
-
-		_, err := packetConnection.WriteTo(buf, addr)
+		_, err := packetConnection.WriteTo([]byte(""), addr)
 
 		if err != nil {
 			panic(err)

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -89,6 +89,10 @@ func MonitorNextNode(
 					break
 				}
 
+				/*
+				 * If we have not come full circle:
+				 * spawn new subroutine to monitor the "next" nextNode
+				 */
 				if nextNodeID != prevNodeID {
 					var nextNextNodeID int
 
@@ -98,7 +102,14 @@ func MonitorNextNode(
 						nextNextNodeID = nextNodeID + 1
 					}
 
-					go MonitorNextNode(nodeID, numNodes, basePort, nextNextNodeID, destroySubroutine, updateNextNode)
+					go MonitorNextNode(
+						nodeID,
+						numNodes,
+						basePort,
+						nextNextNodeID,
+						destroySubroutine,
+						updateNextNode,
+					)
 					hasSubroutine = true
 				}
 

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -1,29 +1,29 @@
 package network
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
-	"runtime"
 	"time"
 
 	"github.com/libp2p/go-reuseport"
 )
 
-const LISTEN_TIMEOUT = 50
-const BUF_SIZE = 2
+const LISTEN_TIMEOUT = 1000
+const BUF_SIZE = 4
 
 /*
  * Recursively monitors the other nodes.
  * The closest (forward in the circle) node that is
  * alive is updated on the updateCurrentNext channel.
  */
-func monitorNext(
+func MonitorNext(
 	nodeID int,
-	nextNodeID int,
 	numNodes int,
 	basePort int,
+	nextNodeID int,
 	selfDestruct chan bool,
-	updateCurrentNext chan int,
+	updateCurrentNext chan string,
 ) {
 	var prevNodeID int
 	hasSubroutine := false
@@ -35,8 +35,10 @@ func monitorNext(
 	}
 
 	destroySubroutine := make(chan bool)
+	buf := make([]byte, BUF_SIZE)
 
-	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%d", basePort+nextNodeID))
+	nextNodePort := basePort + nextNodeID
+	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%d", nextNodePort))
 
 	if err != nil {
 		panic(err)
@@ -58,12 +60,15 @@ func monitorNext(
 		 */
 		default:
 			deadline := time.Now().Add(LISTEN_TIMEOUT * time.Millisecond)
-			packetConnection.SetReadDeadline(deadline)
+			err := packetConnection.SetReadDeadline(deadline)
 
-			buf := make([]byte, BUF_SIZE)
+			if err != nil {
+				panic(err)
+			}
 
-			// TODO: second return value can be used to get IP of the sender
-			_, _, err := packetConnection.ReadFrom(buf)
+			_, addr, err := packetConnection.ReadFrom(buf)
+
+			received := binary.BigEndian.Uint32(buf)
 
 			/*
 			 * UDP read successful, the next node is alive
@@ -74,7 +79,7 @@ func monitorNext(
 					hasSubroutine = false
 				}
 
-				updateCurrentNext <- nextNodeID
+				updateCurrentNext <- fmt.Sprintf("%s - %d", addr.String(), received)
 				break
 			}
 
@@ -95,43 +100,15 @@ func monitorNext(
 						nextNextNodeID = nextNodeID + 1
 					}
 
-					go monitorNext(nodeID, nextNextNodeID, numNodes, basePort, destroySubroutine, updateCurrentNext)
+					go MonitorNext(nodeID, numNodes, basePort, nextNextNodeID, destroySubroutine, updateCurrentNext)
 					hasSubroutine = true
 				}
 
-				updateCurrentNext <- -1
+				updateCurrentNext <- ""
 				break
 			}
 
 			panic(err)
 		}
-	}
-}
-
-/*
- * Monitor and print next nodes
- * TODO: move current next state to main function,
- * pass it out on a channel
- */
-func NextWatchDog(nodeID int, numNodes int, basePort int) {
-	var nextNode int
-
-	if nodeID+1 >= numNodes {
-		nextNode = 0
-	} else {
-		nextNode = nodeID + 1
-	}
-
-	currentNextNode := nextNode
-	updateCurrentNext := make(chan int)
-
-	go monitorNext(nodeID, nextNode, numNodes, basePort, make(chan bool), updateCurrentNext)
-
-	for {
-		fmt.Print("\033[J\033[2;0H\r  ")
-		fmt.Printf("ID: %d | Next: %d | Routines: %d \n  ", nodeID, currentNextNode, runtime.NumGoroutine())
-
-		newNextID := <-updateCurrentNext
-		currentNextNode = newNextID
 	}
 }

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -15,15 +15,15 @@ const BUF_SIZE = 2
 /*
  * Recursively monitors the other nodes.
  * The closest (forward in the circle) node that is
- * alive is updated on the updateCurrentNext channel.
+ * alive is updated on the updateNextNode channel.
  */
-func MonitorNext(
+func MonitorNextNode(
 	nodeID int,
 	numNodes int,
 	basePort int,
 	nextNodeID int,
 	selfDestruct chan bool,
-	updateNextNode chan elevator.Next,
+	updateNextNode chan elevator.NextNode,
 ) {
 	var prevNodeID int
 	hasSubroutine := false
@@ -77,7 +77,7 @@ func MonitorNext(
 					hasSubroutine = false
 				}
 
-				updateNextNode <- elevator.Next{ID: nextNodeID, Addr: addr.String()}
+				updateNextNode <- elevator.NextNode{ID: nextNodeID, Addr: addr.String()}
 				break
 			}
 
@@ -98,11 +98,11 @@ func MonitorNext(
 						nextNextNodeID = nextNodeID + 1
 					}
 
-					go MonitorNext(nodeID, numNodes, basePort, nextNextNodeID, destroySubroutine, updateNextNode)
+					go MonitorNextNode(nodeID, numNodes, basePort, nextNextNodeID, destroySubroutine, updateNextNode)
 					hasSubroutine = true
 				}
 
-				updateNextNode <- elevator.Next{ID: -1, Addr: ""}
+				updateNextNode <- elevator.NextNode{ID: -1, Addr: ""}
 				break
 			}
 


### PR DESCRIPTION
# Changes

- Move the initialisation of the next node watchdog to the main function. 
- Retrieve the next node source address when broadcasting is received. This is sent to the _elevState_ struct on a channel and is to be used to send messages to the next node.
- Change the broadcasting code a bit in order to use the correct ports (maybe this fixes the windows errors?).