### PR TITLE
feat: move side effects out of fsm

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -55,7 +55,9 @@ func UpdateState(
 	elevConfig *types.ElevConfig,
 ) *types.ElevState {
 
-	elevio.SetMotorDirection(stateChanges.Dirn)
+	if stateChanges.SetMotor {
+		elevio.SetMotorDirection(stateChanges.MotorDirn)
+	}
 	elevio.SetDoorOpenLamp(stateChanges.Door)
 
 	if stateChanges.StartDoorTimer {
@@ -64,7 +66,7 @@ func UpdateState(
 
 	newState := types.ElevState{
 		Floor:           oldState.Floor,
-		Dirn:            stateChanges.Dirn,
+		Dirn:            stateChanges.ElevDirn,
 		DoorObstr:       oldState.DoorObstr,
 		Requests:        oldState.Requests,
 		NextNode:        oldState.NextNode,

--- a/src/fsm/fsm.go
+++ b/src/fsm/fsm.go
@@ -2,9 +2,7 @@ package fsm
 
 import (
 	"Driver-go/elevio"
-	"elevator/elev"
 	"elevator/requests"
-	"elevator/timer"
 	"elevator/types"
 )
 
@@ -14,79 +12,100 @@ func OnInitBetweenFloors() {
 	state = types.EB_Moving
 }
 
-func OnRequestButtonPress(
-	buttonPress elevio.ButtonEvent,
+func OnOrderAssigned(
+	newOrder elevio.ButtonEvent,
 	elevState *types.ElevState,
 	elevConfig *types.ElevConfig,
-) {
+) types.FsmOutput {
+
+	output := types.FsmOutput{
+		Dirn:           elevState.Dirn,
+		Door:           state == types.EB_DoorOpen,
+		StartDoorTimer: false,
+	}
+
 	switch state {
 	case types.EB_DoorOpen:
-		if requests.ShouldClearImmediately(elevState, buttonPress) {
-			timer.Start(elevConfig.DoorOpenDuration)
-		} else {
-			elevState.Requests[buttonPress.Floor][buttonPress.Button] = true
+		if requests.ShouldClearImmediately(elevState, newOrder) {
+			output.StartDoorTimer = true
+			output.ClearOrders[newOrder.Button] = true
 		}
 
-	case types.EB_Moving:
-		elevState.Requests[buttonPress.Floor][buttonPress.Button] = true
-
 	case types.EB_Idle:
-		elevState.Requests[buttonPress.Floor][buttonPress.Button] = true
 		pair := requests.ChooseDirection(elevState, elevConfig)
 
-		elevState.Dirn = pair.Dirn
+		output.Dirn = pair.Dirn
 		state = pair.Behaviour
 
-		switch pair.Behaviour {
+		switch state {
 		case types.EB_DoorOpen:
-			elevio.SetDoorOpenLamp(true)
-			timer.Start(elevConfig.DoorOpenDuration)
-			requests.ClearAtcurrentFloor(elevState, elevConfig)
+			output.ClearOrders = requests.ClearAtCurrentFloor(elevState, elevConfig)
+			output.Door = true
+			output.StartDoorTimer = true
 
 		case types.EB_Moving:
-			elevio.SetMotorDirection(pair.Dirn)
+			output.Dirn = pair.Dirn
 		}
 	}
 
-	elev.SetAllLights(elevState, elevConfig)
+	return output
 }
 
 func OnFloorArrival(
-	floor int,
 	elevState *types.ElevState,
 	elevConfig *types.ElevConfig,
-) {
-	elevState.Floor = floor
-	elevio.SetFloorIndicator(elevState.Floor)
+) types.FsmOutput {
+
+	output := types.FsmOutput{
+		Dirn:           elevState.Dirn,
+		Door:           state == types.EB_DoorOpen,
+		StartDoorTimer: false,
+	}
 
 	if state == types.EB_Moving && requests.ShouldStop(elevState, elevConfig) {
-		elevio.SetMotorDirection(elevio.MD_Stop)
-		elevio.SetDoorOpenLamp(true)
+		output.Dirn = elevio.MD_Stop
 
-		requests.ClearAtcurrentFloor(elevState, elevConfig)
+		output.Door = true
+		output.StartDoorTimer = true
 
-		timer.Start(elevConfig.DoorOpenDuration)
-		elev.SetAllLights(elevState, elevConfig)
+		output.ClearOrders = requests.ClearAtCurrentFloor(elevState, elevConfig)
+
 		state = types.EB_DoorOpen
 	}
+
+	return output
 }
 
-func OnDoorTimeout(elevState *types.ElevState, elevConfig *types.ElevConfig) {
+func OnDoorTimeout(
+	elevState *types.ElevState,
+	elevConfig *types.ElevConfig,
+) types.FsmOutput {
+
+	output := types.FsmOutput{
+		Dirn:           elevState.Dirn,
+		Door:           state == types.EB_DoorOpen,
+		StartDoorTimer: false,
+	}
+
 	if state != types.EB_DoorOpen {
-		return
+		return output
 	}
 
 	pair := requests.ChooseDirection(elevState, elevConfig)
 
-	elevState.Dirn = pair.Dirn
+	output.Dirn = pair.Dirn
 	state = pair.Behaviour
 
 	if state == types.EB_DoorOpen {
-		timer.Start(elevConfig.DoorOpenDuration)
-		requests.ClearAtcurrentFloor(elevState, elevConfig)
-		elev.SetAllLights(elevState, elevConfig)
+		output.StartDoorTimer = true
+		output.ClearOrders = requests.ClearAtCurrentFloor(elevState, elevConfig)
 	} else {
 		elevio.SetDoorOpenLamp(false)
 		elevio.SetMotorDirection(elevState.Dirn)
+
+		output.Door = false
+		output.Dirn = pair.Dirn
 	}
+
+	return output
 }

--- a/src/main.go
+++ b/src/main.go
@@ -126,6 +126,9 @@ func main() {
 		 * Handle new next node
 		 */
 		case newNextNode := <-updateNextNode:
+			/*
+			 * TODO: handle reassignment of the dead nodes hall orders
+			 */
 			if elevState.NextNode == newNextNode {
 				continue
 			}

--- a/src/main.go
+++ b/src/main.go
@@ -16,10 +16,10 @@ import (
 const NUM_FLOORS = 4
 const DOOR_OPEN_DURATION = 3000
 
-func main() {
-	/*
-	 * Read command line arguments
-	 */
+/*
+ * Parse command line arguments
+ */
+func parseCommandlineFlags() (int, int, int, int) {
 	nodeID := flag.Int("id", -1, "Node id")
 	numNodes := flag.Int("num", -1, "Number of nodes")
 	baseBroadcastPort := flag.Int("bport", -1, "Base Broadcasting port")
@@ -31,6 +31,12 @@ func main() {
 		fmt.Println("Missing flags, use flag -h to see usage")
 		os.Exit(1)
 	}
+
+	return *nodeID, *numNodes, *baseBroadcastPort, *elevServerPort
+}
+
+func main() {
+	nodeID, numNodes, baseBroadcastPort, elevServerPort := parseCommandlineFlags()
 
 	/*
 	 * Clear terminal window

--- a/src/main.go
+++ b/src/main.go
@@ -7,12 +7,12 @@ import (
 	"elevator/network"
 	"elevator/timer"
 	"elevator/types"
-	"encoding/binary"
 	"flag"
 	"fmt"
 	"os"
 )
 
+const NUM_BUTTONS = 3
 const NUM_FLOORS = 4
 const DOOR_OPEN_DURATION = 3000
 
@@ -47,11 +47,12 @@ func main() {
 	 * Initiate elevator config
 	 */
 	elevConfig, err := elev.InitConfig(
-		*nodeID,
-		*numNodes,
+		nodeID,
+		numNodes,
 		NUM_FLOORS,
+		NUM_BUTTONS,
 		DOOR_OPEN_DURATION,
-		*baseBroadcastPort,
+		baseBroadcastPort,
 	)
 
 	if err != nil {
@@ -61,23 +62,14 @@ func main() {
 	/*
 	 * Initiate elevator state
 	 */
-	elevState := elev.InitState(elevConfig.NumFloors)
+	elevState := elev.InitState(elevConfig)
 
 	/*
-	 * Initiate elevator driver and elevator polling
+	 * Initiate elevator driver
 	 */
-	elevio.Init(fmt.Sprintf("localhost:%d", *elevServerPort), NUM_FLOORS)
-
-	drvButtons := make(chan elevio.ButtonEvent)
-	drvFloors := make(chan int)
-	drvObstr := make(chan bool)
-
-	go elevio.PollButtons(drvButtons)
-	go elevio.PollFloorSensor(drvFloors)
-	go elevio.PollObstructionSwitch(drvObstr)
+	drvButtons, drvFloors, drvObstr := elev.InitDriver(elevServerPort, elevConfig.NumFloors)
 
 	currentFloor := elevio.GetFloor()
-
 	if 0 > currentFloor {
 		elevio.SetMotorDirection(elevio.MD_Down)
 		elevState.Dirn = elevio.MD_Down
@@ -93,21 +85,13 @@ func main() {
 	/*
 	 * Monitor next nodes and update NextNode in elevConfig
 	 */
-	var nextNodeID int
-
-	if elevConfig.NodeID+1 >= elevConfig.NumNodes {
-		nextNodeID = 0
-	} else {
-		nextNodeID = elevConfig.NodeID + 1
-	}
-
 	updateNextNode := make(chan types.NextNode)
 
 	go network.MonitorNextNode(
 		elevConfig.NodeID,
 		elevConfig.NumNodes,
-		*baseBroadcastPort,
-		nextNodeID,
+		baseBroadcastPort,
+		elev.FindNextNodeID(elevConfig),
 		make(chan bool),
 		updateNextNode,
 	)
@@ -118,18 +102,20 @@ func main() {
 	localIP, err := network.LocalIP()
 
 	if err != nil {
-		fmt.Println(err)
-		localIP = "DISCONNECTED"
+		panic(err)
 	}
 
 	incomingMessageChannel := make(chan []byte)
-	go network.ListenForMessages(localIP, elevConfig.BroadcastPort, incomingMessageChannel)
+	go network.ListenForMessages(
+		localIP,
+		elevConfig.BroadcastPort,
+		incomingMessageChannel,
+	)
 
 	/*
 	 * Channels used by secure send
 	 */
 	updateNextNodeAddr := make(chan string)
-	replyReceived := make(chan bool)
 
 	/*
 	 * Main for/select
@@ -153,14 +139,34 @@ func main() {
 		/*
 		 * Handle button presses
 		 */
-		case buttonPress := <-drvButtons:
-			fsm.OnRequestButtonPress(buttonPress, elevState, elevConfig)
+		case newOrder := <-drvButtons:
+			/*
+			 * TODO: assign order properly
+			 */
+			elevState.Requests[newOrder.Floor][newOrder.Button] = true
+
+			output := fsm.OnOrderAssigned(newOrder, elevState, elevConfig)
+
+			elevState = elev.UpdateState(
+				elevState,
+				output,
+				elevConfig,
+			)
 
 		/*
 		 * Handle floor arrivals
 		 */
 		case newCurrentFloor := <-drvFloors:
-			fsm.OnFloorArrival(newCurrentFloor, elevState, elevConfig)
+			elevState.Floor = newCurrentFloor
+			elevio.SetFloorIndicator(newCurrentFloor)
+
+			output := fsm.OnFloorArrival(elevState, elevConfig)
+
+			elevState = elev.UpdateState(
+				elevState,
+				output,
+				elevConfig,
+			)
 
 		/*
 		 * Handle door obstructions
@@ -173,43 +179,11 @@ func main() {
 			timer.Start(elevConfig.DoorOpenDuration)
 			elevState.DoorObstr = isObstructed
 
-			/*
-			 * For testing: send a secure message
-			 */
-			if elevState.WaitingForReply {
-				continue
-			}
-
-			elevState.WaitingForReply = true
-
-			buffer := make([]byte, 4)
-			binary.BigEndian.PutUint32(buffer, uint32(elevConfig.BroadcastPort))
-
-			go network.SecureSend(
-				elevState.NextNode.Addr,
-				buffer,
-				replyReceived,
-				updateNextNodeAddr,
-			)
-
 		/*
 		 * Handle incomming UDP messages
 		 */
-		case message := <-incomingMessageChannel:
-			/*
-			 * ...and receive (or forward) the secure msg
-			 */
-
-			receivedMsg := binary.BigEndian.Uint32(message)
-
-			if receivedMsg == uint32(elevConfig.BroadcastPort) && elevState.WaitingForReply {
-				replyReceived <- true
-				elevState.WaitingForReply = false
-				fmt.Println("Recieved reply!")
-			} else {
-				network.Send(elevState.NextNode.Addr, message)
-				fmt.Println("Received: ", receivedMsg)
-			}
+		case <-incomingMessageChannel:
+			continue
 
 		/*
 		 * Handle door time outs
@@ -220,11 +194,16 @@ func main() {
 					timer.Start(elevConfig.DoorOpenDuration)
 					continue
 				}
-
 				timer.Stop()
-				fsm.OnDoorTimeout(elevState, elevConfig)
+
+				output := fsm.OnDoorTimeout(elevState, elevConfig)
+
+				elevState = elev.UpdateState(
+					elevState,
+					output,
+					elevConfig,
+				)
 			}
-			continue
 		}
 	}
 }

--- a/src/network/receiver.go
+++ b/src/network/receiver.go
@@ -15,7 +15,6 @@ func ListenForMessages(ip string, port int, messageChannelchan chan<- []byte) {
 	conn, err := reuseport.ListenPacket("udp4", fmt.Sprintf("%s:%d", ip, port))
 
 	if err != nil {
-		messageChannelchan <- []byte("CONNECTION ERROR")
 		panic(err)
 	}
 

--- a/src/requests/requests.go
+++ b/src/requests/requests.go
@@ -96,18 +96,25 @@ func ShouldStop(elevState *types.ElevState, elevConfig *types.ElevConfig) bool {
 	}
 }
 
-func ShouldClearImmediately(elevState *types.ElevState, buttonPress elevio.ButtonEvent) bool {
+func ShouldClearImmediately(elevState *types.ElevState, order elevio.ButtonEvent) bool {
 	/*
 	 * TODO: check project requirements to make sure clearing is handled correctly
 	 */
-	return elevState.Floor == buttonPress.Floor
+	return elevState.Floor == order.Floor
 }
 
-func ClearAtcurrentFloor(elevState *types.ElevState, elevConfig *types.ElevConfig) {
+func ClearAtCurrentFloor(
+	elevState *types.ElevState,
+	elevConfig *types.ElevConfig,
+) [3]bool {
 	/*
 	 * ...same here
 	 */
+	var clearOrders [3]bool
+
 	for btn := 0; btn < elevConfig.NumButtons; btn++ {
-		elevState.Requests[elevState.Floor][btn] = false
+		clearOrders[btn] = true
 	}
+
+	return clearOrders
 }

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -17,6 +17,13 @@ const (
 	EB_Moving
 )
 
+type FsmOutput struct {
+	Dirn           elevio.MotorDirection
+	Door           bool
+	ClearOrders    [3]bool
+	StartDoorTimer bool
+}
+
 type NextNode struct {
 	ID   int
 	Addr string

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -18,10 +18,12 @@ const (
 )
 
 type FsmOutput struct {
-	Dirn           elevio.MotorDirection
+	ElevDirn       elevio.MotorDirection
+	MotorDirn      elevio.MotorDirection
+	SetMotor       bool
 	Door           bool
-	ClearOrders    [3]bool
 	StartDoorTimer bool
+	ClearOrders    [3]bool
 }
 
 type NextNode struct {


### PR DESCRIPTION
# Changes

- Move some of the setup code in the main function to separate functions to clean things up a bit.
- Return a struct with side effects from the state machine functions, rather than performing the side effects in the state machine itself. 