### PR TITLE
feat: improve secure send

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -68,12 +68,11 @@ func UpdateState(
 	}
 
 	newState := types.ElevState{
-		Floor:           oldState.Floor,
-		Dirn:            stateChanges.ElevDirn,
-		DoorObstr:       oldState.DoorObstr,
-		Orders:          oldState.Orders,
-		NextNode:        oldState.NextNode,
-		WaitingForReply: oldState.WaitingForReply,
+		Floor:     oldState.Floor,
+		Dirn:      stateChanges.ElevDirn,
+		DoorObstr: oldState.DoorObstr,
+		Orders:    oldState.Orders,
+		NextNode:  oldState.NextNode,
 	}
 
 	for order, clearOrder := range stateChanges.ClearOrders {

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -24,7 +24,7 @@ func GetMsgHeader(encodedMsg []byte) (*types.Header, error) {
 func GetMsgContent[T types.Content](encodedMsg []byte) (*T, error) {
 	var content T
 
-	encodedHeader := encodedMsg[:SIZE_OF_HEADER]
+	encodedHeader := encodedMsg[SIZE_OF_HEADER:]
 
 	err := json.Unmarshal(encodedHeader, &content)
 

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -5,14 +5,32 @@ import (
 	"encoding/json"
 )
 
-func JsonToMsg[T types.Content](encoded []byte) (*types.Msg[T], error) {
-	var msg types.Msg[T]
+const SIZE_OF_HEADER = 23
 
-	err := json.Unmarshal(encoded, &msg)
+func GetMsgHeader(encodedMsg []byte) (*types.Header, error) {
+	var header types.Header
+
+	encodedHeader := encodedMsg[:SIZE_OF_HEADER]
+
+	err := json.Unmarshal(encodedHeader, &header)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &msg, nil
+	return &header, nil
+}
+
+func GetMsgContent[T types.Content](encodedMsg []byte) (*T, error) {
+	var content T
+
+	encodedHeader := encodedMsg[:SIZE_OF_HEADER]
+
+	err := json.Unmarshal(encodedHeader, &content)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &content, nil
 }

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -60,6 +60,10 @@ func SecureSend(
 			addr = newAddr
 
 		case replyHeader := <-replyReceived:
+			if len(msgBuffer) == 0 {
+				continue
+			}
+
 			msgHeader, _ := GetMsgHeader(msgBuffer[0])
 
 			validReply := replyHeader == *msgHeader
@@ -68,9 +72,7 @@ func SecureSend(
 				continue
 			}
 
-			if len(msgBuffer) != 0 {
-				msgBuffer = msgBuffer[1:]
-			}
+			msgBuffer = msgBuffer[1:]
 
 			if len(msgBuffer) == 0 {
 				msgTimeOut.Stop()

--- a/src/types/elev.go
+++ b/src/types/elev.go
@@ -24,5 +24,4 @@ type ElevState struct {
 	DoorObstr       bool
 	Orders          [][][]bool
 	NextNode        NextNode
-	WaitingForReply bool
 }

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -38,25 +39,34 @@ type Sync struct {
 	Orders [][][]bool
 }
 
+type Header struct {
+	Type     MsgTypes
+	AuthorID int // must contain a single digit number [0, 9] in order to properly decode messages
+}
+
 type Content interface {
 	Bid | Assign | Reassign | Served | Sync
 }
 
 type Msg[T Content] struct {
+	Header  Header
 	Content T
 }
 
-type MsgHeader struct {
-	Type     MsgTypes
-	AuthorID int // must contain a single digit number [0, 9] in order to properly decode messages
-}
-
-func (msg Msg[T]) ToJson() ([]byte, error) {
-	encodedMsg, err := json.Marshal(msg)
+func (msg Msg[T]) ToJson() []byte {
+	encodedContent, err := json.Marshal(msg.Content)
 
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
-	return encodedMsg, nil
+	encodedHeader, err := json.Marshal(msg.Header)
+
+	if err != nil {
+		panic(err)
+	}
+
+	separator := []byte("")
+
+	return bytes.Join([][]byte{encodedHeader, encodedContent}, separator)
 }


### PR DESCRIPTION
# Changes

- Refactor message types and json utilities. The message header is now part of the message type.
- Create new secure send routine. This takes new messages in on a channel and adds them to a buffer. This way we can queue messages that are to be securely sent.