### PR TITLE
feat: order assignment and clearing

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,7 +1,7 @@
-go 1.20
+go 1.21
 
 use (
 	./lib/driver-go-master/
-   	./lib/go-reuseport-0.4.0
+   ./lib/go-reuseport-0.4.0
 	./src
 )

--- a/lib/driver-go-master/go.mod
+++ b/lib/driver-go-master/go.mod
@@ -1,3 +1,3 @@
 module Driver-go
 
-go 1.16
+go 1.21

--- a/lib/go-reuseport-0.4.0/go.mod
+++ b/lib/go-reuseport-0.4.0/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-reuseport
 
-go 1.20
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -54,8 +54,8 @@ func InitState(elevConfig *types.ElevConfig) *types.ElevState {
 
 func UpdateState(
 	oldState *types.ElevState,
-	stateChanges types.FsmOutput,
 	elevConfig *types.ElevConfig,
+	stateChanges types.FsmOutput,
 ) *types.ElevState {
 
 	if stateChanges.SetMotor {
@@ -147,8 +147,22 @@ func SetHallLights(orders [][][]bool, elevConfig *types.ElevConfig) {
 	}
 }
 
-func SetCabLights(cabcalls [][]bool, elevConfig *types.ElevConfig) {
-	for floor := range cabcalls {
-		elevio.SetButtonLamp(elevio.BT_Cab, floor, cabcalls[floor][elevio.BT_Cab])
+func SetCabLights(orders [][]bool, elevConfig *types.ElevConfig) {
+	for floor := range orders {
+		elevio.SetButtonLamp(elevio.BT_Cab, floor, orders[floor][elevio.BT_Cab])
 	}
+}
+
+func OnOrderAssigned(
+	elevState *types.ElevState,
+	elevConfig *types.ElevConfig,
+	assignee int,
+	order types.Order,
+) *types.ElevState {
+
+	elevState.Orders[assignee][order.Floor][order.Button] = true
+	SetCabLights(elevState.Orders[elevConfig.NodeID], elevConfig)
+	SetHallLights(elevState.Orders, elevConfig)
+
+	return elevState
 }

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -54,7 +54,7 @@ func InitState(elevConfig *types.ElevConfig) *types.ElevState {
 }
 
 /*
- * 
+ * Takes in output from fsm, performs side effects and return new elev state
  */
 func UpdateState(
 	oldState *types.ElevState,
@@ -94,10 +94,6 @@ func UpdateState(
 			)
 		}
 	}
-
-	cabcalls := newState.Orders[elevConfig.NodeID]
-	SetCabLights(cabcalls, elevConfig)
-	SetHallLights(newState.Orders, elevConfig)
 
 	return &newState
 }
@@ -175,6 +171,7 @@ func OnOrderChanged(
 ) *types.ElevState {
 
 	elevState.Orders[assignee][order.Floor][order.Button] = newStatus
+
 	SetCabLights(elevState.Orders[elevConfig.NodeID], elevConfig)
 	SetHallLights(elevState.Orders, elevConfig)
 

--- a/src/fsm/costFunction.go
+++ b/src/fsm/costFunction.go
@@ -9,9 +9,6 @@ import (
 
 const TRAVEL_TIME = 2000 // ms
 
-/*
- *
- */
 func deepCopy(obj types.ElevState, copy *types.ElevState) {
 	encodedObj, _ := json.Marshal(obj)
 	_ = json.Unmarshal(encodedObj, copy)
@@ -50,6 +47,9 @@ func TimeToOrderServed(elevState *types.ElevState, elevConfig *types.ElevConfig,
 			shouldClear := orders.ClearAtCurrentFloor(&elevSimState, elevConfig)
 
 			if order.Floor == elevSimState.Floor && shouldClear[order.Button] {
+				if 0 > duration {
+					duration = 0
+				}
 				return duration
 			}
 

--- a/src/fsm/costFunction.go
+++ b/src/fsm/costFunction.go
@@ -4,16 +4,27 @@ import (
 	"Driver-go/elevio"
 	"elevator/orders"
 	"elevator/types"
+	"encoding/json"
 )
 
 const TRAVEL_TIME = 2000 // ms
+
+/*
+ *
+ */
+func deepCopy(obj types.ElevState, copy *types.ElevState) {
+	encodedObj, _ := json.Marshal(obj)
+	_ = json.Unmarshal(encodedObj, copy)
+}
 
 func TimeToOrderServed(elevState *types.ElevState, elevConfig *types.ElevConfig, order types.Order) int {
 	if 0 > elevState.Floor {
 		return -1
 	}
 
-	elevSimState := *elevState
+	var elevSimState types.ElevState
+	deepCopy(*elevState, &elevSimState)
+
 	elevSimState.Orders[elevConfig.NodeID][order.Floor][order.Button] = true
 
 	duration := 0

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,3 @@
 module elevator
 
-go 1.20
+go 1.21

--- a/src/main.go
+++ b/src/main.go
@@ -62,7 +62,8 @@ func main() {
 	go network.Broadcast(elevConfig.BroadcastPort)
 
 	/*
-	 * Monitor next nodes and update NextNode in elevConfig
+	 * Monitor next nodes and update NextNode in elevState
+	 * Makes sure we always know which node to send messages to
 	 */
 	updateNextNode := make(chan types.NextNode)
 

--- a/src/main.go
+++ b/src/main.go
@@ -123,6 +123,9 @@ func main() {
 			elevState.NextNode = newNextNode
 			updateNextNodeAddr <- elevState.NextNode.Addr
 
+			fmt.Print("\033[J\033[2;0H\r  ")
+			fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ", elevConfig.NodeID, elevState.NextNode.ID, elevState.NextNode.Addr)
+
 		/*
 		 * Handle button presses
 		 */

--- a/src/main.go
+++ b/src/main.go
@@ -124,7 +124,11 @@ func main() {
 			updateNextNodeAddr <- elevState.NextNode.Addr
 
 			fmt.Print("\033[J\033[2;0H\r  ")
-			fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ", elevConfig.NodeID, elevState.NextNode.ID, elevState.NextNode.Addr)
+			fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ",
+				elevConfig.NodeID,
+				elevState.NextNode.ID,
+				elevState.NextNode.Addr,
+			)
 
 		/*
 		 * Handle button presses

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -49,3 +49,17 @@ func FormatAssignMsg(order types.Order, assignee int, author int) []byte {
 
 	return msg.ToJson()
 }
+
+func FormatServedMsg(order types.Order, author int) []byte {
+	msg := types.Msg[types.Served]{
+		Header: types.Header{
+			Type:     types.SERVED,
+			AuthorID: author,
+		},
+		Content: types.Served{
+			Order: order,
+		},
+	}
+
+	return msg.ToJson()
+}

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -34,3 +34,18 @@ func GetMsgContent[T types.Content](encodedMsg []byte) (*T, error) {
 
 	return &content, nil
 }
+
+func FormatAssignMsg(order types.Order, assignee int, author int) []byte {
+	msg := types.Msg[types.Assign]{
+		Header: types.Header{
+			Type:     types.ASSIGN,
+			AuthorID: author,
+		},
+		Content: types.Assign{
+			Order:    order,
+			Assignee: assignee,
+		},
+	}
+
+	return msg.ToJson()
+}

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -63,3 +63,28 @@ func FormatServedMsg(order types.Order, author int) []byte {
 
 	return msg.ToJson()
 }
+
+func FormatBidMsg(order types.Order, numNodes int, author int) []byte {
+	timeToServed := make([]int, numNodes)
+
+	/*
+	 * Dead nodes will not add their time to served
+	 * -> value of -1 means we can ignore the value
+	 */
+	for NodeID := range timeToServed {
+		timeToServed[NodeID] = -1
+	}
+
+	msg := types.Msg[types.Bid]{
+		Header: types.Header{
+			Type:     types.BID,
+			AuthorID: author,
+		},
+		Content: types.Bid{
+			Order:        order,
+			TimeToServed: timeToServed,
+		},
+	}
+
+	return msg.ToJson()
+}

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -64,15 +64,14 @@ func FormatServedMsg(order types.Order, author int) []byte {
 	return msg.ToJson()
 }
 
-func FormatBidMsg(order types.Order, numNodes int, author int) []byte {
-	timeToServed := make([]int, numNodes)
+func FormatBidMsg(timeToServed []int, order types.Order, NumNodes int, author int) []byte {
+	if len(timeToServed) == 0 {
 
-	/*
-	 * Dead nodes will not add their time to served
-	 * -> value of -1 means we can ignore the value
-	 */
-	for NodeID := range timeToServed {
-		timeToServed[NodeID] = -1
+		timeToServed = make([]int, NumNodes)
+
+		for NodeID := range timeToServed {
+			timeToServed[NodeID] = -1
+		}
 	}
 
 	msg := types.Msg[types.Bid]{

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -59,6 +59,10 @@ func SecureSend(
 		case newAddr := <-updateAddr:
 			addr = newAddr
 
+			if addr == "" {
+				msgBuffer = nil
+			}
+
 		case replyHeader := <-replyReceived:
 			if len(msgBuffer) == 0 {
 				continue

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -78,7 +78,7 @@ func MonitorNextNode(
 				}
 
 				updateNextNode <- types.NextNode{ID: nextNodeID, Addr: addr.String()}
-				break
+				continue
 			}
 
 			/*
@@ -89,32 +89,34 @@ func MonitorNextNode(
 					break
 				}
 
+				if nextNodeID+1 == prevNodeID {
+					updateNextNode <- types.NextNode{ID: -1, Addr: ""}
+					continue
+				}
+
 				/*
 				 * If we have not come full circle:
 				 * spawn new subroutine to monitor the "next" nextNode
 				 */
-				if nextNodeID != prevNodeID {
-					var nextNextNodeID int
+				var nextNextNodeID int
 
-					if nextNodeID+1 >= numNodes {
-						nextNextNodeID = 0
-					} else {
-						nextNextNodeID = nextNodeID + 1
-					}
-
-					go MonitorNextNode(
-						nodeID,
-						numNodes,
-						basePort,
-						nextNextNodeID,
-						destroySubroutine,
-						updateNextNode,
-					)
-					hasSubroutine = true
+				if nextNodeID+1 >= numNodes {
+					nextNextNodeID = 0
+				} else {
+					nextNextNodeID = nextNodeID + 1
 				}
 
-				updateNextNode <- types.NextNode{ID: -1, Addr: ""}
-				break
+				go MonitorNextNode(
+					nodeID,
+					numNodes,
+					basePort,
+					nextNextNodeID,
+					destroySubroutine,
+					updateNextNode,
+				)
+				hasSubroutine = true
+
+				continue
 			}
 
 			panic(err)

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -89,7 +89,7 @@ func MonitorNextNode(
 					break
 				}
 
-				if nextNodeID+1 == prevNodeID {
+				if nextNodeID == prevNodeID {
 					updateNextNode <- types.NextNode{ID: -1, Addr: ""}
 					continue
 				}

--- a/src/types/elev.go
+++ b/src/types/elev.go
@@ -24,4 +24,5 @@ type ElevState struct {
 	DoorObstr       bool
 	Orders          [][][]bool
 	NextNode        NextNode
+	ProcessingOrder bool
 }

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -39,9 +39,13 @@ type Sync struct {
 	Orders [][][]bool
 }
 
+/*
+ * Header must have a fixed size
+ * -> AuthorID must be btween 0 and 9
+ */
 type Header struct {
 	Type     MsgTypes
-	AuthorID int // must contain a single digit number [0, 9] in order to properly decode messages
+	AuthorID int
 }
 
 type Content interface {
@@ -53,6 +57,10 @@ type Msg[T Content] struct {
 	Content T
 }
 
+/*
+ * Parses message header and content to json separately in
+ * order to retrieve content type from header upon msg receival
+ */
 func (msg Msg[T]) ToJson() []byte {
 	encodedContent, err := json.Marshal(msg.Content)
 

--- a/src/utils.go
+++ b/src/utils.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 )
 
 /*
@@ -23,4 +24,21 @@ func parseCommandlineFlags() (int, int, int, int) {
 	}
 
 	return *nodeID, *numNodes, *baseBroadcastPort, *elevServerPort
+}
+
+/*
+ * Find the index of the lowest value that is not -1
+ */
+func MinTimeToServed(timeToServed []int) int {
+	result := slices.Max(timeToServed)
+
+	for _, value := range timeToServed {
+		if 0 > value {
+			continue
+		} else if value < result {
+			result = value
+		}
+	}
+
+	return slices.Index(timeToServed, result)
 }

--- a/src/utils.go
+++ b/src/utils.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+/*
+ * Parse command line arguments
+ */
+func parseCommandlineFlags() (int, int, int, int) {
+	nodeID := flag.Int("id", -1, "Node id")
+	numNodes := flag.Int("num", -1, "Number of nodes")
+	baseBroadcastPort := flag.Int("bport", -1, "Base Broadcasting port")
+	elevServerPort := flag.Int("sport", -1, "Elevator server port")
+
+	flag.Parse()
+
+	if *nodeID < 0 || *numNodes < 0 || *baseBroadcastPort < 0 || *elevServerPort < 0 {
+		fmt.Println("Missing flags, use flag -h to see usage")
+		os.Exit(1)
+	}
+
+	return *nodeID, *numNodes, *baseBroadcastPort, *elevServerPort
+}


### PR DESCRIPTION
# Changes
- Fix deep copy and make sure output is exclusively positive in time to served function.
- Add utils file in main package.
- Cab orders are self-assigned immediately,
- while hall orders are assigned after a bidding round.
- While a new order is being processed (bid and assign) we refuse to take new orders. This is at a per elevator basis.
- Previously the watchdog would send a -1 next node id out to main on read timeout even though it hadn't checked all nodes. This has been fixed.
- Re-add printing of next node state, as it is a bit neat.
