### PR TITLE
feat: door obstruction order reassignment

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -215,3 +215,27 @@ func OnSync(elevState *types.ElevState,
 
 	return elevState
 }
+
+func ReassignOrders(
+	elevState *types.ElevState,
+	elevConfig *types.ElevConfig,
+	sendSecureMsg chan<- []byte,
+) {
+
+	for floor := range elevState.Orders[elevConfig.NodeID] {
+		for btn, order := range elevState.Orders[elevConfig.NodeID][floor] {
+			if order && btn != elevio.BT_Cab {
+				sendSecureMsg <- network.FormatBidMsg(
+					nil,
+					types.Order{
+						Button: elevio.ButtonType(btn),
+						Floor:  floor,
+					},
+					elevConfig.NodeID,
+					elevConfig.NumNodes,
+					elevConfig.NodeID,
+				)
+			}
+		}
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
 	"elevator/network"
 	"elevator/timer"
 	"elevator/types"
+	"fmt"
 	"time"
 )
 
@@ -147,12 +148,6 @@ func main() {
 		 * Handle button presses
 		 */
 		case newOrder := <-drvButtons:
-			if elevState.ProcessingOrder {
-				continue
-			}
-
-			elevState.ProcessingOrder = true
-
 			/*
 			 * Cab orders are directly selfassigned
 			 */
@@ -305,8 +300,6 @@ func main() {
 				 */
 				if !isReply {
 					network.Send(elevState.NextNode.Addr, encodedMsg)
-				} else {
-					elevState.ProcessingOrder = false
 				}
 
 				if assignMsg.NewAssignee != elevConfig.NodeID {

--- a/src/main.go
+++ b/src/main.go
@@ -107,16 +107,9 @@ func main() {
 	)
 
 	/*
-	 * Setup times
+	 * Setup timers
 	 */
-	doorTimeout := make(chan bool)
-	doorTimer := make(chan types.TimerActions)
-
-	go timer.Timer(
-		DOOR_OPEN_DURATION*time.Millisecond,
-		doorTimeout,
-		doorTimer,
-	)
+	doorTimeout, doorTimer := timer.New(DOOR_OPEN_DURATION * time.Millisecond)
 
 	/*
 	 * Main for/select

--- a/src/main.go
+++ b/src/main.go
@@ -160,7 +160,7 @@ func main() {
 				sendSecureMsg <- network.FormatAssignMsg(
 					newOrder,
 					elevConfig.NodeID,
-					-1,
+					int(types.UNASSIGNED),
 					elevConfig.NodeID,
 				)
 
@@ -173,7 +173,7 @@ func main() {
 			sendSecureMsg <- network.FormatBidMsg(
 				nil,
 				newOrder,
-				-1,
+				int(types.UNASSIGNED),
 				elevConfig.NumNodes,
 				elevConfig.NodeID,
 			)
@@ -289,7 +289,7 @@ func main() {
 				/*
 				 * In case of an order reassign
 				 */
-				if assignMsg.OldAssignee != -1 {
+				if assignMsg.OldAssignee != int(types.UNASSIGNED) {
 					elevState = elev.OnOrderChanged(
 						elevState,
 						elevConfig,

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -41,6 +41,7 @@ func FormatAssignMsg(
 	oldAssignee int,
 	author int,
 ) []byte {
+
 	msg := types.Msg[types.Assign]{
 		Header: types.Header{
 			Type:     types.ASSIGN,

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -35,15 +35,21 @@ func GetMsgContent[T types.Content](encodedMsg []byte) (*T, error) {
 	return &content, nil
 }
 
-func FormatAssignMsg(order types.Order, assignee int, author int) []byte {
+func FormatAssignMsg(
+	order types.Order,
+	newAssignee int,
+	oldAssignee int,
+	author int,
+) []byte {
 	msg := types.Msg[types.Assign]{
 		Header: types.Header{
 			Type:     types.ASSIGN,
 			AuthorID: author,
 		},
 		Content: types.Assign{
-			Order:    order,
-			Assignee: assignee,
+			Order:       order,
+			NewAssignee: newAssignee,
+			OldAssignee: oldAssignee,
 		},
 	}
 
@@ -67,10 +73,10 @@ func FormatServedMsg(order types.Order, author int) []byte {
 func FormatBidMsg(
 	timeToServed []int,
 	order types.Order,
+	oldAssignee int,
 	NumNodes int,
 	author int,
 ) []byte {
-
 	if len(timeToServed) == 0 {
 		timeToServed = make([]int, NumNodes)
 
@@ -87,6 +93,7 @@ func FormatBidMsg(
 		Content: types.Bid{
 			Order:        order,
 			TimeToServed: timeToServed,
+			OldAssignee:  oldAssignee,
 		},
 	}
 

--- a/src/timer/timer.go
+++ b/src/timer/timer.go
@@ -45,7 +45,7 @@ func New(duration time.Duration) (chan bool, chan types.TimerActions) {
 	timer := make(chan types.TimerActions)
 
 	go Timer(
-		duration*time.Millisecond,
+		duration,
 		timeout,
 		timer,
 	)

--- a/src/timer/timer.go
+++ b/src/timer/timer.go
@@ -38,5 +38,17 @@ func Timer(
 			continue
 		}
 	}
+}
 
+func New(duration time.Duration) (chan bool, chan types.TimerActions) {
+	timeout := make(chan bool)
+	timer := make(chan types.TimerActions)
+
+	go Timer(
+		duration*time.Millisecond,
+		timeout,
+		timer,
+	)
+
+	return timeout, timer
 }

--- a/src/types/elev.go
+++ b/src/types/elev.go
@@ -19,10 +19,9 @@ type ElevConfig struct {
 }
 
 type ElevState struct {
-	Floor           int
-	Dirn            elevio.MotorDirection
-	DoorObstr       bool
-	Orders          [][][]bool
-	NextNode        NextNode
-	ProcessingOrder bool
+	Floor     int
+	Dirn      elevio.MotorDirection
+	DoorObstr bool
+	Orders    [][][]bool
+	NextNode  NextNode
 }

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -15,17 +15,17 @@ const (
 	SYNC
 )
 
+/*
+ * OldAssignee is set on reassignment bids
+ * and -1 for assignment bids
+ */
 type Bid struct {
 	Order        Order
 	TimeToServed []int
+	OldAssignee  int
 }
 
 type Assign struct {
-	Order    Order
-	Assignee int
-}
-
-type Reassign struct {
 	Order       Order
 	NewAssignee int
 	OldAssignee int
@@ -50,7 +50,7 @@ type Header struct {
 }
 
 type Content interface {
-	Bid | Assign | Reassign | Served | Sync
+	Bid | Assign | Served | Sync
 }
 
 type Msg[T Content] struct {

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -15,6 +15,10 @@ const (
 	SYNC
 )
 
+type OrderStatus int
+
+const UNASSIGNED OrderStatus = -1
+
 /*
  * OldAssignee is set on reassignment bids
  * and -1 for assignment bids


### PR DESCRIPTION
# Changes
- Merge assign and reassign messages. If the message field `OldAssignee` is set we know that the message is a reassignment.
- Create utility for creating new timers.
- Add door obstruction timeout to reassign orders if the elevator door i obstructed for too long.