### PR TITLE
feat: order reassignment on disconnect

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -234,7 +234,7 @@ func ReassignOrders(
 					},
 					nodeID,
 					elevConfig.NumNodes,
-					nodeID,
+					elevConfig.NodeID,
 				)
 			}
 		}

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -219,11 +219,12 @@ func OnSync(elevState *types.ElevState,
 func ReassignOrders(
 	elevState *types.ElevState,
 	elevConfig *types.ElevConfig,
+	nodeID int,
 	sendSecureMsg chan<- []byte,
 ) {
 
-	for floor := range elevState.Orders[elevConfig.NodeID] {
-		for btn, order := range elevState.Orders[elevConfig.NodeID][floor] {
+	for floor := range elevState.Orders[nodeID] {
+		for btn, order := range elevState.Orders[nodeID][floor] {
 			if order && btn != elevio.BT_Cab {
 				sendSecureMsg <- network.FormatBidMsg(
 					nil,
@@ -231,9 +232,9 @@ func ReassignOrders(
 						Button: elevio.ButtonType(btn),
 						Floor:  floor,
 					},
-					elevConfig.NodeID,
+					nodeID,
 					elevConfig.NumNodes,
-					elevConfig.NodeID,
+					nodeID,
 				)
 			}
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -440,11 +440,16 @@ func main() {
 				sendSecureMsg,
 			)
 
+		/*
+		 * Reassign order if we are stuck between floors
+		 */
 		case <-floorTimeout:
 			elevState.StuckBetweenFloors = true
+
 			elev.ReassignOrders(
 				elevState,
 				elevConfig,
+				elevConfig.NodeID,
 				sendSecureMsg,
 			)
 

--- a/src/main.go
+++ b/src/main.go
@@ -58,6 +58,7 @@ func main() {
 	 */
 	updateNextNode := make(chan types.NextNode)
 	syncNextNode := make(chan int)
+	reassignOrders := make(chan int)
 
 	go network.MonitorNextNode(
 		elevConfig,
@@ -65,6 +66,7 @@ func main() {
 
 		updateNextNode,
 		syncNextNode,
+		reassignOrders,
 
 		make(chan bool),
 		make(chan bool),
@@ -143,6 +145,16 @@ func main() {
 				elevState.Orders,
 				elevConfig.NodeID,
 			)
+
+		case lostNode := <-reassignOrders:
+
+			elev.ReassignOrders(
+				elevState,
+				elevConfig,
+				lostNode,
+				sendSecureMsg,
+			)
+			fmt.Println("Orders reassigned")
 
 		/*
 		 * Handle button presses
@@ -373,6 +385,7 @@ func main() {
 					sendSecureMsg,
 					doorTimer,
 				)
+				fmt.Println("Orders updated")
 			}
 
 			/*
@@ -411,6 +424,7 @@ func main() {
 			elev.ReassignOrders(
 				elevState,
 				elevConfig,
+				elevConfig.NodeID,
 				sendSecureMsg,
 			)
 

--- a/src/main.go
+++ b/src/main.go
@@ -7,7 +7,6 @@ import (
 	"elevator/network"
 	"elevator/timer"
 	"elevator/types"
-	"fmt"
 	"time"
 )
 
@@ -147,14 +146,12 @@ func main() {
 			)
 
 		case lostNode := <-reassignOrders:
-
 			elev.ReassignOrders(
 				elevState,
 				elevConfig,
 				lostNode,
 				sendSecureMsg,
 			)
-			fmt.Println("Orders reassigned")
 
 		/*
 		 * Handle button presses
@@ -385,7 +382,6 @@ func main() {
 					sendSecureMsg,
 					doorTimer,
 				)
-				fmt.Println("Orders updated")
 			}
 
 			/*

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -78,6 +78,7 @@ func FormatBidMsg(
 	NumNodes int,
 	author int,
 ) []byte {
+
 	if len(timeToServed) == 0 {
 		timeToServed = make([]int, NumNodes)
 

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -92,7 +92,6 @@ func MonitorNextNode(
 				}
 
 				if !isAlive {
-					fmt.Println("Starting Sync")
 					nodeRevived <- nextNodeID
 				}
 
@@ -120,7 +119,6 @@ func MonitorNextNode(
 			}
 
 			if previouslyAlive {
-				fmt.Println("Lost Node", nextNodeID)
 				nodeDied <- nextNodeID
 				previouslyAlive = false
 			}

--- a/src/utils.go
+++ b/src/utils.go
@@ -45,10 +45,11 @@ func minTimeToServed(timeToServed []int) int {
 }
 
 func printNextNode(elevState *types.ElevState, elevConfig *types.ElevConfig) {
-	fmt.Print("\033[2J\033[2;0H\r  ")
+	// fmt.Print("\033[2J\033[2;0H\r  ")
 	fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ",
 		elevConfig.NodeID,
 		elevState.NextNode.ID,
 		elevState.NextNode.Addr,
 	)
+	fmt.Println()
 }

--- a/src/utils.go
+++ b/src/utils.go
@@ -45,11 +45,10 @@ func minTimeToServed(timeToServed []int) int {
 }
 
 func printNextNode(elevState *types.ElevState, elevConfig *types.ElevConfig) {
-	// fmt.Print("\033[2J\033[2;0H\r  ")
-	fmt.Printf("ID: %d | NextID: %d | NextAddr: %s ",
+	fmt.Print("\033[2J\033[2;0H\r  ")
+	fmt.Printf("ID: %d | NextID: %d | NextAddr: %s \n",
 		elevConfig.NodeID,
 		elevState.NextNode.ID,
 		elevState.NextNode.Addr,
 	)
-	fmt.Println()
 }


### PR DESCRIPTION
# Changes
- Watchdog will now trigger a reassignment of orders when a node disconnects from the network.
- Added nodeID to elev.ReassignOrders.
- Refactored printNextNode to not clear terminal but add a newline.