### PR TITLE
feat: update synchronisation mechanism to sync all elevators

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -57,7 +57,7 @@ func main() {
 	 * Makes sure we always know which node to send messages to
 	 */
 	updateNextNode := make(chan types.NextNode)
-	syncNextNode := make(chan bool)
+	nextNodeRevived := make(chan bool)
 	reassignOrders := make(chan int)
 
 	go network.MonitorNextNode(
@@ -65,7 +65,7 @@ func main() {
 		elev.FindNextNodeID(elevConfig),
 
 		updateNextNode,
-		syncNextNode,
+		nextNodeRevived,
 		reassignOrders,
 
 		make(chan bool),
@@ -141,7 +141,7 @@ func main() {
 		/*
 		 * Sync new next node
 		 */
-		case <-syncNextNode:
+		case <-nextNodeRevived:
 			sendSecureMsg <- network.FormatSyncMsg(
 				elevState.Orders,
 				elevConfig.NodeID,

--- a/src/main.go
+++ b/src/main.go
@@ -58,7 +58,7 @@ func main() {
 	 */
 	updateNextNode := make(chan types.NextNode)
 	nextNodeRevived := make(chan bool)
-	reassignOrders := make(chan int)
+	nextNodeDied := make(chan int)
 
 	go network.MonitorNextNode(
 		elevConfig,
@@ -66,7 +66,7 @@ func main() {
 
 		updateNextNode,
 		nextNodeRevived,
-		reassignOrders,
+		nextNodeDied,
 
 		make(chan bool),
 		make(chan bool),
@@ -147,7 +147,7 @@ func main() {
 				elevConfig.NodeID,
 			)
 
-		case lostNode := <-reassignOrders:
+		case lostNode := <-nextNodeDied:
 			elev.ReassignOrders(
 				elevState,
 				elevConfig,

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -102,15 +102,14 @@ func FormatBidMsg(
 	return msg.ToJson()
 }
 
-func FormatSyncMsg(targetID int, orders [][][]bool, author int) []byte {
+func FormatSyncMsg(orders [][][]bool, author int) []byte {
 	msg := types.Msg[types.Sync]{
 		Header: types.Header{
 			Type:     types.SYNC,
 			AuthorID: author,
 		},
 		Content: types.Sync{
-			Orders:   orders,
-			TargetID: targetID,
+			Orders: orders,
 		},
 	}
 

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -22,7 +22,7 @@ func MonitorNextNode(
 	nextNodeID int,
 
 	updateNextNode chan<- types.NextNode,
-	nodeRevived chan<- int,
+	nodeRevived chan<- bool,
 	nodeDied chan<- int,
 
 	terminationComplete chan bool,
@@ -92,7 +92,7 @@ func MonitorNextNode(
 				}
 
 				if !isAlive {
-					nodeRevived <- nextNodeID
+					nodeRevived <- true
 				}
 
 				isAlive = true

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -40,8 +40,7 @@ type Served struct {
 }
 
 type Sync struct {
-	Orders   [][][]bool
-	TargetID int
+	Orders [][][]bool
 }
 
 /*


### PR DESCRIPTION
# Changes
- Sync mechanism now updates all nodes in the network. If a disconnected node receives ned cab calls, the new orders will be synced to the network once a connection has been established.
- Refactored the Sync struct and FormatSyncMsg to only require necessary parameters (removed target id).