### PR TITLE
feat: disconnected mode

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -91,7 +91,22 @@ func UpdateState(
 	 * Clear served orders
 	 */
 	for order, clearOrder := range stateChanges.ClearOrders {
-		if clearOrder {
+		if !clearOrder {
+			continue
+		}
+
+		if newState.Disconnected {
+			newState = *OnOrderChanged(
+				&newState,
+				elevConfig,
+				elevConfig.NodeID,
+				types.Order{
+					Button: elevio.ButtonType(order),
+					Floor:  newState.Floor,
+				},
+				false,
+			)
+		} else {
 			sendSecureMsg <- network.FormatServedMsg(
 				types.Order{
 					Button: elevio.ButtonType(order),

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -73,11 +73,12 @@ func UpdateState(
 	}
 
 	newState := types.ElevState{
-		Floor:     oldState.Floor,
-		Dirn:      stateChanges.ElevDirn,
-		DoorObstr: oldState.DoorObstr,
-		Orders:    oldState.Orders,
-		NextNode:  oldState.NextNode,
+		Floor:        oldState.Floor,
+		Dirn:         stateChanges.ElevDirn,
+		DoorObstr:    oldState.DoorObstr,
+		Orders:       oldState.Orders,
+		NextNode:     oldState.NextNode,
+		Disconnected: oldState.Disconnected,
 	}
 
 	/*

--- a/src/network/broadcast.go
+++ b/src/network/broadcast.go
@@ -14,7 +14,7 @@ const BROADCAST_INTERVAL = 100
 /*
  * Broadcasts "I'm alive" on specified port.
  */
-func Broadcast(port int, networkDisconnectChannel chan bool) {
+func Broadcast(port int, networkStatus chan<- bool) {
 	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%d", port))
 
 	if err != nil {
@@ -29,7 +29,7 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 	}
 
 	disconnected := false
-	oldDisconnected := false
+	prevNetworkStatus := false
 
 	for {
 		time.Sleep(BROADCAST_INTERVAL * time.Millisecond)
@@ -42,9 +42,9 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 			disconnected = false
 		}
 
-		if disconnected != oldDisconnected {
-			networkDisconnectChannel <- disconnected
-			oldDisconnected = disconnected
+		if disconnected != prevNetworkStatus {
+			networkStatus <- disconnected
+			prevNetworkStatus = disconnected
 		}
 	}
 }

--- a/src/network/broadcast.go
+++ b/src/network/broadcast.go
@@ -18,14 +18,14 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%d", port))
 
 	if err != nil {
-		panic(err)
+		panic("Could not connect to network")
 	}
 	defer packetConnection.Close()
 
 	addr, err := net.ResolveUDPAddr("udp4", fmt.Sprintf("%s:%d", BROADCAST_IP, port))
 
 	if err != nil {
-		panic(err)
+		panic("Could not resolve address")
 	}
 
 	disconnected := false
@@ -43,8 +43,6 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 		}
 
 		if disconnected != oldDisconnected {
-			fmt.Println("broadcast diconnected:", disconnected)
-
 			networkDisconnectChannel <- disconnected
 			oldDisconnected = disconnected
 		}

--- a/src/network/broadcast.go
+++ b/src/network/broadcast.go
@@ -28,8 +28,8 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 		panic(err)
 	}
 
-	networkDisconnect := false
-	oldNetworkDisconnect := false
+	disconnected := false
+	oldDisconnected := false
 
 	for {
 		time.Sleep(BROADCAST_INTERVAL * time.Millisecond)
@@ -37,14 +37,16 @@ func Broadcast(port int, networkDisconnectChannel chan bool) {
 		_, err := packetConnection.WriteTo([]byte(""), addr)
 
 		if err != nil {
-			networkDisconnect = true
+			disconnected = true
 		} else {
-			networkDisconnect = false // set to true for test purposes
+			disconnected = false
 		}
 
-		if networkDisconnect != oldNetworkDisconnect {
-			networkDisconnectChannel <- networkDisconnect
-			oldNetworkDisconnect = networkDisconnect
+		if disconnected != oldDisconnected {
+			fmt.Println("broadcast diconnected:", disconnected)
+
+			networkDisconnectChannel <- disconnected
+			oldDisconnected = disconnected
 		}
 	}
 }

--- a/src/network/localip.go
+++ b/src/network/localip.go
@@ -10,7 +10,7 @@ var localIP string
 /*
  * Fetch the local IP address of the machine.
  * If the IP address has already been fetched, the function returns the cached value.
- * This code is copied from: https://github.com/TTK4145/Network-go/blob/master/network/localip/localip.go
+ * Code borrowed from: https://github.com/TTK4145/Network-go/blob/master/network/localip/localip.go
  */
 func LocalIP() (string, error) {
 	if localIP == "" {

--- a/src/network/messages.go
+++ b/src/network/messages.go
@@ -102,14 +102,15 @@ func FormatBidMsg(
 	return msg.ToJson()
 }
 
-func FormatSyncMsg(orders [][][]bool, author int) []byte {
+func FormatSyncMsg(orders [][][]bool, targetID int, author int) []byte {
 	msg := types.Msg[types.Sync]{
 		Header: types.Header{
 			Type:     types.SYNC,
 			AuthorID: author,
 		},
 		Content: types.Sync{
-			Orders: orders,
+			Orders:   orders,
+			TargetID: targetID,
 		},
 	}
 

--- a/src/network/receiver.go
+++ b/src/network/receiver.go
@@ -23,7 +23,7 @@ func ListenForMessages(
 	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf("%s:%d", ip, port))
 
 	if err != nil {
-		panic(err)
+		panic("Could not connect to network")
 	}
 
 	defer packetConnection.Close()
@@ -35,7 +35,6 @@ func ListenForMessages(
 	for {
 		select {
 		case disconnected = <-disconnectedChannel:
-			fmt.Println("listen disconnect: ", disconnected)
 
 		default:
 			if disconnected {

--- a/src/network/receiver.go
+++ b/src/network/receiver.go
@@ -36,6 +36,7 @@ func ListenForMessages(
 			if disconnected {
 				continue
 			}
+
 			n, _, _ := conn.ReadFrom(buffer)
 			messageChannel <- buffer[:n]
 		}

--- a/src/network/receiver.go
+++ b/src/network/receiver.go
@@ -13,8 +13,8 @@ import (
 func ListenForMessages(
 	ip string,
 	port int,
-	messageChannel chan<- []byte,
-	disconnectedChannel chan bool,
+	outgoingMessage chan<- []byte,
+	disableListen chan bool,
 ) {
 
 	const BUFFER_SIZE = 1024
@@ -30,14 +30,14 @@ func ListenForMessages(
 
 	buffer := make([]byte, BUFFER_SIZE)
 
-	var disconnected bool
+	var disabled bool
 
 	for {
 		select {
-		case disconnected = <-disconnectedChannel:
+		case disabled = <-disableListen:
 
 		default:
-			if disconnected {
+			if disabled {
 				continue
 			}
 
@@ -54,7 +54,7 @@ func ListenForMessages(
 				continue
 			}
 
-			messageChannel <- buffer[:n]
+			outgoingMessage <- buffer[:n]
 		}
 	}
 }

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -67,7 +67,6 @@ func SecureSend(
 			}
 
 		case disconnected = <-disconnectedChan:
-			fmt.Println("send disconnected:", disconnected)
 
 		case replyHeader := <-replyReceived:
 

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -67,12 +67,7 @@ func SecureSend(
 			}
 
 		case disconnected = <-disconnectedChan:
-			fmt.Println("case: send diconnected:", disconnected)
-
-			if disconnected {
-				msgBuffer = nil
-				msgTimeOut.Stop()
-			}
+			fmt.Println("send disconnected:", disconnected)
 
 		case replyHeader := <-replyReceived:
 
@@ -113,7 +108,7 @@ func SecureSend(
 
 		case <-msgTimeOut.C:
 
-			if len(msgBuffer) > 0 {
+			if len(msgBuffer) > 0 && !disconnected {
 				Send(addr, msgBuffer[0])
 			}
 

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -23,18 +23,18 @@ func Send(addr string, msg []byte) {
 	receiverPort := strings.Split(addr, ":")[1]
 	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%s", receiverPort))
 	if err != nil {
-		panic(err)
+		return
 	}
 	defer packetConnection.Close()
 
 	resolvedAddr, err := net.ResolveUDPAddr("udp4", addr)
 	if err != nil {
-		panic(err)
+		return
 	}
 
 	_, err = packetConnection.WriteTo(msg, resolvedAddr)
 	if err != nil {
-		panic(err)
+		return
 	}
 }
 
@@ -63,12 +63,15 @@ func SecureSend(
 
 			if addr == "" {
 				msgBuffer = nil
+				msgTimeOut.Stop()
 			}
 
 		case disconnected = <-disconnectedChan:
+			fmt.Println("case: send diconnected:", disconnected)
 
 			if disconnected {
 				msgBuffer = nil
+				msgTimeOut.Stop()
 			}
 
 		case replyHeader := <-replyReceived:

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -41,7 +41,7 @@ func MonitorNextNode(
 	packetConnection, err := reuseport.ListenPacket("udp4", fmt.Sprintf(":%d", nextNodePort))
 
 	if err != nil {
-		panic(err)
+		return
 	}
 	defer packetConnection.Close()
 
@@ -65,7 +65,7 @@ func MonitorNextNode(
 			err := packetConnection.SetReadDeadline(deadline)
 
 			if err != nil {
-				panic(err)
+				continue
 			}
 
 			_, addr, err := packetConnection.ReadFrom(msgBuffer)
@@ -104,7 +104,7 @@ func MonitorNextNode(
 			 */
 			nErr, ok := err.(net.Error)
 			if !ok || !nErr.Timeout() {
-				panic(err)
+				continue
 			}
 
 			/*

--- a/src/types/elev.go
+++ b/src/types/elev.go
@@ -25,4 +25,5 @@ type ElevState struct {
 	Orders          [][][]bool
 	NextNode        NextNode
 	ProcessingOrder bool
+	Disconnected    bool
 }

--- a/src/types/network.go
+++ b/src/types/network.go
@@ -40,7 +40,8 @@ type Served struct {
 }
 
 type Sync struct {
-	Orders [][][]bool
+	Orders   [][][]bool
+	TargetID int
 }
 
 /*

--- a/src/utils.go
+++ b/src/utils.go
@@ -45,7 +45,7 @@ func minTimeToServed(timeToServed []int) int {
 }
 
 func printNextNode(elevState *types.ElevState, elevConfig *types.ElevConfig) {
-	// fmt.Print("\033[2J\033[2;0H\r  ")
+	fmt.Print("\033[2J\033[2;0H\r  ")
 	fmt.Printf("ID: %d | NextID: %d | NextAddr: %s \n",
 		elevConfig.NodeID,
 		elevState.NextNode.ID,

--- a/src/utils.go
+++ b/src/utils.go
@@ -45,7 +45,7 @@ func minTimeToServed(timeToServed []int) int {
 }
 
 func printNextNode(elevState *types.ElevState, elevConfig *types.ElevConfig) {
-	fmt.Print("\033[2J\033[2;0H\r  ")
+	// fmt.Print("\033[2J\033[2;0H\r  ")
 	fmt.Printf("ID: %d | NextID: %d | NextAddr: %s \n",
 		elevConfig.NodeID,
 		elevState.NextNode.ID,


### PR DESCRIPTION
# Changes

- Includes a way to detect if an elevator is no longer connected to the network, as specified in the the project description. On broadcast failure, it is assumed that the network connection is lost, and the elevator enters a disconnect state that alters the handling of orders, sending and listening for messages.