### PR TITLE
feat: single elevator mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.exe
 bin
 *.bin
+.VSCodeCounter

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -4,7 +4,6 @@ import (
 	"Driver-go/elevio"
 	"elevator/network"
 	"elevator/types"
-	"errors"
 	"fmt"
 )
 
@@ -15,10 +14,10 @@ func InitConfig(
 	numButtons int,
 	doorOpenDuration int,
 	basePort int,
-) (*types.ElevConfig, error) {
+) *types.ElevConfig {
 
 	if nodeID+1 > numNodes {
-		return nil, errors.New("node id greater than number of nodes")
+		panic("Node id greater than number of nodes")
 	}
 
 	elevator := types.ElevConfig{
@@ -30,7 +29,7 @@ func InitConfig(
 		BroadcastPort:    basePort + nodeID,
 	}
 
-	return &elevator, nil
+	return &elevator
 }
 
 func InitState(elevConfig *types.ElevConfig) *types.ElevState {
@@ -147,18 +146,6 @@ func InitDriver(
 	SetHallLights(elevState.Orders, elevConfig)
 
 	return drvButtons, drvFloors, drvObstr
-}
-
-func FindNextNodeID(elevConfig *types.ElevConfig) int {
-	var nextNodeID int
-
-	if elevConfig.NodeID+1 >= elevConfig.NumNodes {
-		nextNodeID = 0
-	} else {
-		nextNodeID = elevConfig.NodeID + 1
-	}
-
-	return nextNodeID
 }
 
 func SetHallLights(orders [][][]bool, elevConfig *types.ElevConfig) {

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -179,6 +179,29 @@ func SetCabLights(orders [][]bool, elevConfig *types.ElevConfig) {
 	}
 }
 
+func OnDoorObstr(
+	elevState *types.ElevState,
+	isObstructed bool,
+	obstrTimer chan types.TimerActions,
+	doorTimer chan types.TimerActions,
+) *types.ElevState {
+
+	if elevState.DoorObstr == isObstructed {
+		return elevState
+	}
+
+	if isObstructed {
+		obstrTimer <- types.START
+	} else {
+		obstrTimer <- types.STOP
+	}
+
+	doorTimer <- types.START
+	elevState.DoorObstr = isObstructed
+
+	return elevState
+}
+
 func OnOrderChanged(
 	elevState *types.ElevState,
 	elevConfig *types.ElevConfig,

--- a/src/main.go
+++ b/src/main.go
@@ -65,9 +65,6 @@ func main() {
 
 	for {
 		select {
-		/*
-		 * Handle new next node
-		 */
 		case newNextNode := <-updateNextNode:
 			if elevState.NextNode == newNextNode {
 				continue
@@ -92,9 +89,6 @@ func main() {
 				sendSecureMsg,
 			)
 
-		/*
-		 * Update elevator network status
-		 */
 		case disconnected := <-networkStatus:
 			if !disconnected {
 				updateNextNode, nextNodeRevived, nextNodeDied = network.InitWatchdog(elevConfig)
@@ -105,9 +99,6 @@ func main() {
 			disableListen <- disconnected
 			disableSecureSend <- disconnected
 
-		/*
-		 * Handle incomming orders (button presses)
-		 */
 		case newOrder := <-drvButtons:
 			elevState = elev.HandleNewOrder(
 				elevState,
@@ -118,9 +109,6 @@ func main() {
 				floorTimer,
 			)
 
-		/*
-		 * Handle floor arrivals
-		 */
 		case newFloor := <-drvFloors:
 			elevState = elev.HandleFloorArrival(
 				elevState,
@@ -131,9 +119,6 @@ func main() {
 				floorTimer,
 			)
 
-		/*
-		 * Handle door obstructions
-		 */
 		case isObstructed := <-drvObstr:
 			elevState = elev.HandleDoorObstr(
 				elevState,
@@ -142,9 +127,6 @@ func main() {
 				doorTimer,
 			)
 
-		/*
-		 * Handle incomming UDP messages
-		 */
 		case encodedMsg := <-incomingMessage:
 			header, err := network.GetMsgHeader(encodedMsg)
 
@@ -160,9 +142,6 @@ func main() {
 
 			switch header.Type {
 			case types.BID:
-				/*
-				 * Handle bid
-				 */
 				bidMsg, err := network.GetMsgContent[types.Bid](encodedMsg)
 
 				if err != nil {
@@ -199,9 +178,6 @@ func main() {
 				)
 
 			case types.ASSIGN:
-				/*
-				 * Handle assign
-				 */
 				assignMsg, err := network.GetMsgContent[types.Assign](encodedMsg)
 
 				if err != nil {
@@ -216,9 +192,6 @@ func main() {
 					true,
 				)
 
-				/*
-				 * In case of an order reassign
-				 */
 				if assignMsg.OldAssignee != int(types.UNASSIGNED) {
 					elevState = elev.SetOrderStatus(
 						elevState,
@@ -259,9 +232,6 @@ func main() {
 				continue
 
 			case types.SERVED:
-				/*
-				 * Handle served
-				 */
 				servedMsg, err := network.GetMsgContent[types.Served](encodedMsg)
 
 				if err != nil {
@@ -277,9 +247,6 @@ func main() {
 				)
 
 			case types.SYNC:
-				/*
-				 * Handle sync
-				 */
 				syncMsg, err := network.GetMsgContent[types.Sync](encodedMsg)
 
 				if err != nil {
@@ -310,9 +277,6 @@ func main() {
 				encodedMsg = network.FormatSyncMsg(elevState.Orders, syncMsg.TargetID, header.AuthorID)
 			}
 
-			/*
-			 * Forward message
-			 */
 			if !isReply {
 				network.Send(elevState.NextNode.Addr, encodedMsg)
 			}
@@ -345,9 +309,6 @@ func main() {
 			)
 
 		default:
-			/*
-			 * Do nothing
-			 */
 			continue
 		}
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -114,7 +114,7 @@ func main() {
 			 */
 			if elevState.Disconnected {
 				if newOrder.Button == elevio.BT_Cab {
-					elevState = elev.OnOrderChanged(
+					elevState = elev.SetOrderStatus(
 						elevState,
 						elevConfig,
 						elevConfig.NodeID,
@@ -124,7 +124,7 @@ func main() {
 
 					fsmOutput := fsm.OnOrderAssigned(newOrder, elevState, elevConfig)
 
-					elevState = elev.UpdateState(
+					elevState = elev.SetState(
 						elevState,
 						elevConfig,
 						fsmOutput,
@@ -176,7 +176,7 @@ func main() {
 
 			fsmOutput := fsm.OnFloorArrival(elevState, elevConfig)
 
-			elevState = elev.UpdateState(
+			elevState = elev.SetState(
 				elevState,
 				elevConfig,
 				fsmOutput,
@@ -266,7 +266,7 @@ func main() {
 					continue
 				}
 
-				elevState = elev.OnOrderChanged(
+				elevState = elev.SetOrderStatus(
 					elevState,
 					elevConfig,
 					assignMsg.NewAssignee,
@@ -278,7 +278,7 @@ func main() {
 				 * In case of an order reassign
 				 */
 				if assignMsg.OldAssignee != int(types.UNASSIGNED) {
-					elevState = elev.OnOrderChanged(
+					elevState = elev.SetOrderStatus(
 						elevState,
 						elevConfig,
 						assignMsg.OldAssignee,
@@ -305,7 +305,7 @@ func main() {
 					elevConfig,
 				)
 
-				elevState = elev.UpdateState(
+				elevState = elev.SetState(
 					elevState,
 					elevConfig,
 					fsmOutput,
@@ -326,7 +326,7 @@ func main() {
 					continue
 				}
 
-				elevState = elev.OnOrderChanged(
+				elevState = elev.SetOrderStatus(
 					elevState,
 					elevConfig,
 					header.AuthorID,
@@ -355,7 +355,7 @@ func main() {
 				if isTarget && elevState.Dirn == elevio.MD_Stop {
 					fsmOutput := fsm.OnSync(elevState, elevConfig)
 
-					elevState = elev.UpdateState(
+					elevState = elev.SetState(
 						elevState,
 						elevConfig,
 						fsmOutput,
@@ -387,7 +387,7 @@ func main() {
 
 			fsmOutput := fsm.OnDoorTimeout(elevState, elevConfig)
 
-			elevState = elev.UpdateState(
+			elevState = elev.SetState(
 				elevState,
 				elevConfig,
 				fsmOutput,

--- a/src/main.go
+++ b/src/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	elevState := elev.InitState(elevConfig)
 
-	incomingMessageChannel, disableListen := network.InitReceiver(elevConfig.BroadcastPort)
+	incomingMessage, disableListen := network.InitReceiver(elevConfig.BroadcastPort)
 
 	updateNextNode, nextNodeRevived, nextNodeDied := network.InitWatchdog(elevConfig)
 
@@ -145,7 +145,7 @@ func main() {
 		/*
 		 * Handle incomming UDP messages
 		 */
-		case encodedMsg := <-incomingMessageChannel:
+		case encodedMsg := <-incomingMessage:
 			header, err := network.GetMsgHeader(encodedMsg)
 
 			if err != nil {

--- a/src/network/receiver.go
+++ b/src/network/receiver.go
@@ -58,3 +58,17 @@ func ListenForMessages(
 		}
 	}
 }
+
+func InitReceiver(port int) (chan []byte, chan bool) {
+	incomingMessageChannel := make(chan []byte)
+	disableListen := make(chan bool)
+
+	go ListenForMessages(
+		LocalIP(),
+		port,
+		incomingMessageChannel,
+		disableListen,
+	)
+
+	return incomingMessageChannel, disableListen
+}

--- a/src/network/sender.go
+++ b/src/network/sender.go
@@ -113,3 +113,19 @@ func SecureSend(
 		}
 	}
 }
+
+func InitSecureSend() (chan string, chan types.Header, chan []byte, chan bool) {
+	updateNextNodeAddr := make(chan string)
+	replyReceived := make(chan types.Header)
+	sendSecureMsg := make(chan []byte)
+	disableSecureSend := make(chan bool)
+
+	go SecureSend(
+		updateNextNodeAddr,
+		replyReceived,
+		sendSecureMsg,
+		disableSecureSend,
+	)
+
+	return updateNextNodeAddr, replyReceived, sendSecureMsg, disableSecureSend
+}

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -122,13 +122,12 @@ func MonitorNextNode(
 
 			if previouslyAlive {
 				nodeDied <- nextNodeID
-
 				previouslyAlive = false
 			}
 
 			if nextNodeID == calcPrevNodeID(elevConfig) {
 				/*
-				 * There are no other nodes alive
+				 * There are no other nodes alive, enter single elev mode
 				 */
 				if isAlive {
 					updateNextNode <- types.NextNode{

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -132,8 +132,8 @@ func MonitorNextNode(
 				 */
 				if isAlive {
 					updateNextNode <- types.NextNode{
-						ID:   -1,
-						Addr: "",
+						ID:   elevConfig.NodeID,
+						Addr: fmt.Sprintf("%s:%d", LocalIP(), elevConfig.BroadcastPort),
 					}
 				}
 

--- a/src/network/watchdog.go
+++ b/src/network/watchdog.go
@@ -187,3 +187,23 @@ func calcNextNodeID(elevConfig *types.ElevConfig, nodeID int) int {
 
 	return nextNodeID
 }
+
+func InitWatchdog(elevConfig *types.ElevConfig) (chan types.NextNode, chan int, chan int) {
+	updateNextNode := make(chan types.NextNode)
+	nextNodeRevived := make(chan int)
+	nextNodeDied := make(chan int)
+
+	go MonitorNextNode(
+		elevConfig,
+		calcNextNodeID(elevConfig, elevConfig.NodeID),
+
+		updateNextNode,
+		nextNodeRevived,
+		nextNodeDied,
+
+		make(chan bool),
+		make(chan bool),
+	)
+
+	return updateNextNode, nextNodeRevived, nextNodeDied
+}

--- a/src/types/elev.go
+++ b/src/types/elev.go
@@ -25,5 +25,5 @@ type ElevState struct {
 	DoorObstr          bool
 	Orders             [][][]bool
 	NextNode           NextNode
-	Disconnected        bool
+	Disconnected       bool
 }


### PR DESCRIPTION
# Changes
- It struct me that dealing with the single elevator mode is as simple as setting the Next node address to your own listening address. This way you simply send messages to yourself. Closes #33 
- I also created init functions for all the network modules,
- as well as some handlers for new orders, door obstructions and floor arrivals. All this frees up a fair bit of space in main.